### PR TITLE
Saat submit POST ke Create/Edit Event seharusnya Schedule menggunakan format Datetime Timezone UTC

### DIFF
--- a/components/EventForm.vue
+++ b/components/EventForm.vue
@@ -110,6 +110,7 @@
 <script>
 /* eslint-disable camelcase */
 import { mapGetters } from 'vuex'
+import { format } from 'date-fns'
 
 export default {
   props: {
@@ -144,9 +145,13 @@ export default {
       let kloter = [null]
       if (val) {
         kloter = val.schedules.map((sch) => {
-          const [startH, startM] = sch.start_at.split('T')[1].split(':')
-          const [endH, endM] = sch.end_at.split('T')[1].split(':')
-          return `${startH}:${startM}-${endH}:${endM}`
+          const scheduleStart = new Date(sch.start_at)
+          const scheduleEnd = new Date(sch.end_at)
+
+          const inputScheduleStart = format(scheduleStart, 'HH:mm')
+          const inputScheduleEnd = format(scheduleEnd, 'HH:mm')
+
+          return `${inputScheduleStart}-${inputScheduleEnd}`
         })
       }
       this.event_name = val ? val.event_name : null

--- a/components/EventForm.vue
+++ b/components/EventForm.vue
@@ -176,21 +176,18 @@ export default {
     doStore() {
       const schedules = this.kloter.map((waktu, i) => {
         let [start_atSch, end_atSch] = waktu.split('-')
-        const { setHours, setMinutes, format } = this.$dateFns
-        start_atSch = format(
-          setHours(
-            setMinutes(new Date(this.tanggal), start_atSch.split(':')[1]),
-            start_atSch.split(':')[0]
-          ),
-          "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
+        const { setHours, setMinutes } = this.$dateFns
+
+        start_atSch = setHours(
+          setMinutes(new Date(this.tanggal), start_atSch.split(':')[1]),
+          start_atSch.split(':')[0]
         )
-        end_atSch = format(
-          setHours(
-            setMinutes(new Date(this.tanggal), end_atSch.split(':')[1]),
-            end_atSch.split(':')[0]
-          ),
-          "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
+
+        end_atSch = setHours(
+          setMinutes(new Date(this.tanggal), end_atSch.split(':')[1]),
+          end_atSch.split(':')[0]
         )
+
         const id = (this.formData && this.formData.schedules[i].id) || null
         return id
           ? {


### PR DESCRIPTION
Behavior Saat ini:

Saat create event:
![image](https://user-images.githubusercontent.com/618412/90544061-cabb7d00-e1b0-11ea-922a-a00c27bf5d59.png)

Setelah berhasil create event, view detail event:
![image](https://user-images.githubusercontent.com/618412/90544139-e888e200-e1b0-11ea-811b-2509e54cd0e6.png)

POST data form yang dikirimkan ke backend:
![image](https://user-images.githubusercontent.com/618412/90544201-ff2f3900-e1b0-11ea-90cd-0770d9f0244b.png)

Seharusnya untuk attribut `start_at` dan `end_at` (termasuk yang ada di array `schedules`), dikirimkan dengan dikonversi ke timezone UTC dulu. Jadi harusnya itu yang dikirimkan adalah, dari input user pukul 14:00 WIB, saat disubmit ke server jadi 07:00 UTC.

Sebenarnya Javascript Date maupun `date-fns`, saat object di-serialize dia akan otomatis dikonversi ke format ISO8601 juga (termasuk akan diubah ke UTC), sehingga tidak perlu ada mekanisme formating dari aplikasi.